### PR TITLE
Add template name param to renderPage helper

### DIFF
--- a/router_helpers.js
+++ b/router_helpers.js
@@ -1,7 +1,8 @@
 if (typeof Handlebars !== 'undefined') {
-  Handlebars.registerHelper('renderPage', function() {
-    var name = Meteor.Router.page();
-    
+  Handlebars.registerHelper('renderPage', function(name) {
+		if(typeof name.length == 'undefined'){
+    	name = Meteor.Router.page();
+  	}
     if (Template[name])
       return new Handlebars.SafeString(Template[name]());
   });


### PR DESCRIPTION
For use mainly in the meteor-transitioner project. but may have other applications. For example:

```
{{renderPage currentScreen}}
```

or

```
[[renderPage "news"}}
```

(second one untested)

The checking of template name is a little hairy. Not sure the best way of checking if something is passed in?
