### PR TITLE
Add support for notifications

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -44,7 +44,7 @@ Note that this doesn't reload the app, it instead uses HTML5 `pushState` to chan
 
 #### Notifications
 
-Unlike session variables, notifications exist only until the page is refreshed. This makes them ideal for giving feedback to users after a form submission. You can define any notification name, e.g. alert, error, success, info.
+Unlike session variables, notifications exist only until the page changes with Router.to(). This makes them ideal for giving feedback to users after a form submission. You can define any notification name, e.g. alert, error, success, info.
 
 To navigate to a page with a notification:
 

--- a/README.markdown
+++ b/README.markdown
@@ -42,6 +42,24 @@ Meteor.Router.to('/news');
 
 Note that this doesn't reload the app, it instead uses HTML5 `pushState` to change the URL whilst remaining loaded.
 
+#### Notifications
+
+Unlike session variables, notifications exist only until the page is refreshed. This makes them ideal for giving feedback to users after a form submission. You can define any notification name, e.g. alert, error, success, info.
+
+To navigate to a page with a notification:
+
+```js
+Meteor.Router.to('/', {alert: 'Brief site maintenance at 2pm EST.'});
+Meteor.Router.notification('alert'); // 'Brief site maintenance at 2pm EST.'
+
+Meteor.Router.to('/', {error: 'Wrong username/password combination!'});
+Meteor.Router.notification('error'); // 'Wrong username/password combination!'
+
+Meteor.Router.to('/profile', {success: 'Logged in successfully!', alert: 'Please set a profile picture.'});
+Meteor.Router.notification('success'); // 'Logged in successfully!'
+Meteor.Router.notification('alert'); // 'Please set a profile picture.'
+```
+
 #### Route Matches
 
 When the route function is called, `this` corresponds to a page.js [`Context`](https://github.com/visionmedia/page.js#contextcanonicalpath), allowing you to do the following:

--- a/router_client.js
+++ b/router_client.js
@@ -1,6 +1,7 @@
 (function() {
   var Router = function() {
     this._page = null;
+    this._notification = {};
     this._autorunHandle = null;
     this._filters = {};
     this._activeFilters = [];
@@ -21,7 +22,12 @@
       var args = [];
       for (key in context.params)
         args.push(context.params[key]);
-      
+
+      // update notifications with user-defined options 
+      // when _page is updated
+      delete (context.state['path']);
+      self._notification = context.state;
+
       var oldPage = self._page;
       self._page = self._applyFilters(pageFn.apply(context, args));
       
@@ -29,7 +35,7 @@
       (oldPage !== self._page) && self.listeners.invalidateAll();
     })
   }
-  
+
   Router.prototype.add = function(path, endpoint) {
     var self = this;
     
@@ -49,9 +55,13 @@
     this.listeners.addCurrentContext();
     return this._page;
   }
-  
-  Router.prototype.to = function(path) {
-    page(path);
+
+  Router.prototype.notification = function(type) {
+    return this._notification[type];
+  }
+
+  Router.prototype.to = function(path, options) {
+    page(path, options);
   }
   
   Router.prototype.filters = function(filtersMap) {

--- a/router_client.js
+++ b/router_client.js
@@ -28,11 +28,10 @@
       delete (context.state['path']);
       self._notification = context.state;
 
-      var oldPage = self._page;
       self._page = self._applyFilters(pageFn.apply(context, args));
       
-      // no need to invalidate if .page() hasn't changed
-      (oldPage !== self._page) && self.listeners.invalidateAll();
+      // invalidate even if .page() hasn't changed to display notifications
+      return self.listeners.invalidateAll();
     })
   }
 

--- a/router_client_tests.js
+++ b/router_client_tests.js
@@ -54,10 +54,9 @@ Tinytest.add("Router reactivity", function(test) {
   Meteor.flush()
   test.equal(context_called, 3);
   
-  // returns 'bar' to shouldn't trigger reactivity
   Meteor.Router.to('/bar/2')
   Meteor.flush()
-  test.equal(context_called, 3);
+  test.equal(context_called, 4);
 });
 
 Tinytest.add("Router filtering", function(test) {

--- a/router_client_tests.js
+++ b/router_client_tests.js
@@ -109,3 +109,18 @@ Tinytest.add("FilteredRouter filter reactivity", function(test) {
   Meteor.flush();
   test.equal(Meteor.Router.page(), 'something_else');
 });
+
+Tinytest.add("Router notifications", function(test) {
+  Meteor.Router.resetFilters();
+  Meteor.Router.add('/foo', 'foo');
+
+  Meteor.Router.to('/foo', {success: 'Successfully logged in!'});
+  test.equal(Meteor.Router.notification('success'), 'Successfully logged in!');
+
+  Meteor.Router.to('/foo', {error: 'Wrong email/password combination'});
+  test.equal(Meteor.Router.notification('error'), 'Wrong email/password combination');
+
+  Meteor.Router.to('/foo', {success: 'Successfully logged in!', alert: 'Site maintenance in 1 hour'});
+  test.equal(Meteor.Router.notification('success'), 'Successfully logged in!');
+  test.equal(Meteor.Router.notification('alert'), 'Site maintenance in 1 hour');
+});


### PR DESCRIPTION
A lot of times I want to set a notification to give a user feedback on a redirect or a form submission (the server's response after a validation, for instance), but having to set and remove session variables isn't elegant in this case. This also seems like something that the vast majority of projects do, but as far as I can tell, developers cobble together their own solutions right now.

Here's an example use case:

A user tries to access his profile without being logged in. I want to have 'Must be logged in!' appear on the screen when I redirect them with the checkLoggedIn filter.

```
Meteor.Router.to('/', {alert: 'Must be logged in!'});
```

I can retrieve that alert and display it with this really simple command, and paste this return into a template:

```
Meteor.Router.notification('alert'); // 'Must be logged in!'
```

These notifications are modeled on Rails' redirect_to messages, which I'm a big fan of.

http://guides.rubyonrails.org/layouts_and_rendering.html#using-redirect_to

Also, all the tests were passing for me, and I wrote several more, but I have yet to try this in a project.
