### PR TITLE
Added support to restrict server side routes by HTTP method

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ Meteor.Router.add('/posts/:id.xml', function(id) {
 });
 ```
 
+Optionally you can also restrict the route by HTTP method:
+
+``` javascript
+Meteor.Router.add('/posts/:id.xml', 'GET', function(id) {
+  return constructXMLForId(Posts.findOne(id));
+});
+Meteor.Router.add('/posts/:id.xml', 'DELETE', function(id) {
+  Posts.remove(id);
+  return [204, 'No Content'];
+});
+```
+
 The arguments to the routing function are the parameters you've specified in your URL, and the `this` within the function is an object with three properties:
 
 * `this.params` -- the list of parameters, page.js style

--- a/router_server_tests.js
+++ b/router_server_tests.js
@@ -70,3 +70,25 @@ Tinytest.add("Router.serve with futures", function(test) {
   var resp = Meteor.http.get('http://localhost:3000/delayed')
   test.equal(resp.content, 'foo-in-timeout');
 });
+
+
+Tinytest.add("Router.serve without http method restriction", function(test) {
+  Meteor.Router.add('/bat-1', 'data');
+  var resp = Meteor.http.get('http://localhost:3000/bat-1');
+  test.equal(resp.content, 'data');
+  var resp = Meteor.http.post('http://localhost:3000/bat-1');
+  test.equal(resp.content, 'data');
+});
+
+
+Tinytest.add("Router.serve with http method restriction", function(test) {
+  Meteor.Router.add('/bat-2', 'GET', 'data');
+  Meteor.Router.add('/bat-2', 'POST', 'postdata');
+  var resp = Meteor.http.get('http://localhost:3000/bat-2');
+  test.equal(resp.content, 'data');
+  var resp = Meteor.http.post('http://localhost:3000/bat-2');
+  test.equal(resp.content, 'postdata');
+  var resp = Meteor.http.put('http://localhost:3000/bat-2');
+  test.notEqual(resp.content, 'postdata');
+  test.notEqual(resp.content, 'data');
+});


### PR DESCRIPTION
Added optional second parameter to Meteor.Router.add on server side to specify the HTTP method which the route should be called with. Example:

``` javascript
Meteor.Router.add('/posts/:id.xml', 'GET', function(id) {
  return constructXMLForId(Posts.findOne(id));
});
Meteor.Router.add('/posts/:id.xml', 'DELETE', function(id) {
  Posts.remove(id);
  return [204, 'No Content'];
});
```

The implementation is completely backwards compatible, so if you don't specify an HTTP method, the route will still be accessible with all HTTP methods.
