### PR TITLE
add rawBody middleware for server routes

### DIFF
--- a/router_server.js
+++ b/router_server.js
@@ -163,6 +163,18 @@
   var connect = __meteor_bootstrap__.require("connect");
   __meteor_bootstrap__.app
     .use(connect.query()) // <- XXX: we can probably assume accounts did this
+    .use(function(req, res, next) {
+      var data = "";
+      if (req.method === "GET" || req.method === "HEAD") return next();
+      req.setEncoding("utf8");
+      req.on("data", function(chunk) {
+        data += chunk;
+      });
+      req.on("end", function() {
+        req.rawBody = data;
+        next();
+      });
+    })
     .use(connect.bodyParser())
     .use(function(req, res, next) {
       // need to wrap in a fiber in case they do something async 


### PR DESCRIPTION
Allows access to a property `rawBody` on `this.request` for server routes. Added this feature as an express middleware.

Note that this addition may be unnecessary... connect.bodyParser() should have done the trick, but I was not able to get it to parse POST requests automatically (these were originating from AWS SNS).

I instead rely on doing `JSON.parse(this.request.rawBody)`.
