### PR TITLE
Remove unneeded escape from 'after\_filter'

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Meteor.Router.add({
 
 ### Filtering
 
-The current system of filtering in this package is the equivalent of an `after\_filter` in Rails. To add a filter which will render the correct template for a page which requires login:
+The current system of filtering in this package is the equivalent of an `after_filter` in Rails. To add a filter which will render the correct template for a page which requires login:
 
 ``` javascript
 Meteor.Router.filters({


### PR DESCRIPTION
Presently, the affected text renders as 'after_filter' on GitHub:
https://github.com/tmeasday/meteor-router#filtering

GitHub Flavored Markdown modifies standard markdown's handling of underscores,
negating the need to escape underscores appearing in words or code blocks.
For details on these modifications, check out the "Code" section toward the
end of the GFM docs:
https://help.github.com/articles/github-flavored-markdown
