### PR TITLE
Test with Meteor running on any port

### DIFF
--- a/router_server_tests.js
+++ b/router_server_tests.js
@@ -10,10 +10,10 @@ Tinytest.add("Simple Router.serve", function(test) {
     return [number, 'page'];
   });
 
-  var resp = Meteor.http.get('http://localhost:3000/server/foo')
+  var resp = Meteor.http.get(Meteor.absoluteUrl('server/foo'));
   test.equal(resp.content, 'data');
 
-  var resp = Meteor.http.get('http://localhost:3000/server/page/7')
+  var resp = Meteor.http.get(Meteor.absoluteUrl('server/page/7'));
   test.equal(resp.statusCode, 7);
   test.equal(resp.content, 'page');
 });
@@ -23,7 +23,7 @@ Tinytest.add("Router.serve with params", function(test) {
     return id;
   })
 
-  var resp = Meteor.http.get('http://localhost:3000/server/bar/content.xml')
+  var resp = Meteor.http.get(Meteor.absoluteUrl('server/bar/content.xml'));
   test.equal(resp.content, 'content');
 });
 
@@ -37,28 +37,28 @@ Tinytest.add("Router.serve various response types", function(test) {
     '/server/baz-5': 'data'
   });
 
-  var resp = Meteor.http.get('http://localhost:3000/server/baz-1')
+  var resp = Meteor.http.get(Meteor.absoluteUrl('server/baz-1'));
   test.equal(resp.statusCode, 404);
   test.equal(resp.content, 'data');
   test.equal(resp.headers['x-my-header'], 'Baz');
 
   // grab it again to make sure we aren't messing with it
-  var resp = Meteor.http.get('http://localhost:3000/server/baz-1')
+  var resp = Meteor.http.get(Meteor.absoluteUrl('server/baz-1'));
   test.equal(resp.statusCode, 404);
   test.equal(resp.content, 'data');
   test.equal(resp.headers['x-my-header'], 'Baz');
 
-  var resp = Meteor.http.get('http://localhost:3000/server/baz-2')
+  var resp = Meteor.http.get(Meteor.absoluteUrl('server/baz-2'));
   test.equal(resp.statusCode, 405);
   test.equal(resp.content, 'data');
 
-  var resp = Meteor.http.get('http://localhost:3000/server/baz-3')
+  var resp = Meteor.http.get(Meteor.absoluteUrl('server/baz-3'));
   test.equal(resp.content, 'data');
 
-  var resp = Meteor.http.get('http://localhost:3000/server/baz-4')
+  var resp = Meteor.http.get(Meteor.absoluteUrl('server/baz-4'));
   test.equal(resp.statusCode, 406);
 
-  var resp = Meteor.http.get('http://localhost:3000/server/baz-5')
+  var resp = Meteor.http.get(Meteor.absoluteUrl('server/baz-5'));
   test.equal(resp.content, 'data');
 });
 
@@ -74,16 +74,16 @@ Tinytest.add("Router.serve with futures", function(test) {
     return fut.wait();
   });
 
-  var resp = Meteor.http.get('http://localhost:3000/server/delayed')
+  var resp = Meteor.http.get(Meteor.absoluteUrl('server/delayed'));
   test.equal(resp.content, 'foo-in-timeout');
 });
 
 
 Tinytest.add("Router.serve without http method restriction", function(test) {
   Meteor.Router.add('/bat-1', 'data');
-  var resp = Meteor.http.get('http://localhost:3000/bat-1');
+  var resp = Meteor.http.get(Meteor.absoluteUrl('bat-1'));
   test.equal(resp.content, 'data');
-  var resp = Meteor.http.post('http://localhost:3000/bat-1');
+  var resp = Meteor.http.post(Meteor.absoluteUrl('bat-1'));
   test.equal(resp.content, 'data');
 });
 
@@ -91,11 +91,11 @@ Tinytest.add("Router.serve without http method restriction", function(test) {
 Tinytest.add("Router.serve with http method restriction", function(test) {
   Meteor.Router.add('/bat-2', 'GET', 'data');
   Meteor.Router.add('/bat-2', 'POST', 'postdata');
-  var resp = Meteor.http.get('http://localhost:3000/bat-2');
+  var resp = Meteor.http.get(Meteor.absoluteUrl('bat-2'));
   test.equal(resp.content, 'data');
-  var resp = Meteor.http.post('http://localhost:3000/bat-2');
+  var resp = Meteor.http.post(Meteor.absoluteUrl('bat-2'));
   test.equal(resp.content, 'postdata');
-  var resp = Meteor.http.put('http://localhost:3000/bat-2');
+  var resp = Meteor.http.put(Meteor.absoluteUrl('bat-2'));
   test.notEqual(resp.content, 'postdata');
   test.notEqual(resp.content, 'data');
 });

--- a/router_server_tests.js
+++ b/router_server_tests.js
@@ -1,18 +1,18 @@
-// XXX: is it OK to assume localhost:3000 here? 
+// XXX: is it OK to assume localhost:3000 here?
 //
 // it seems that stream does in it's tests.
 Tinytest.add("Simple Router.serve", function(test) {
   Meteor.Router.add('/server/foo', function() {
     return 'data';
   });
-  
+
   Meteor.Router.add(/server\/page\/(\d+)/, function(number) {
     return [number, 'page'];
   });
-  
+
   var resp = Meteor.http.get('http://localhost:3000/server/foo')
   test.equal(resp.content, 'data');
-  
+
   var resp = Meteor.http.get('http://localhost:3000/server/page/7')
   test.equal(resp.statusCode, 7);
   test.equal(resp.content, 'page');
@@ -22,7 +22,7 @@ Tinytest.add("Router.serve with params", function(test) {
   Meteor.Router.add('/server/bar/:id.xml', function(id) {
     return id;
   })
-  
+
   var resp = Meteor.http.get('http://localhost:3000/server/bar/content.xml')
   test.equal(resp.content, 'content');
 });
@@ -36,28 +36,28 @@ Tinytest.add("Router.serve various response types", function(test) {
     '/server/baz-4': 406,
     '/server/baz-5': 'data'
   });
-  
+
   var resp = Meteor.http.get('http://localhost:3000/server/baz-1')
   test.equal(resp.statusCode, 404);
   test.equal(resp.content, 'data');
   test.equal(resp.headers['x-my-header'], 'Baz');
-  
+
   // grab it again to make sure we aren't messing with it
   var resp = Meteor.http.get('http://localhost:3000/server/baz-1')
   test.equal(resp.statusCode, 404);
   test.equal(resp.content, 'data');
   test.equal(resp.headers['x-my-header'], 'Baz');
-  
+
   var resp = Meteor.http.get('http://localhost:3000/server/baz-2')
   test.equal(resp.statusCode, 405);
   test.equal(resp.content, 'data');
-  
+
   var resp = Meteor.http.get('http://localhost:3000/server/baz-3')
   test.equal(resp.content, 'data');
-  
+
   var resp = Meteor.http.get('http://localhost:3000/server/baz-4')
   test.equal(resp.statusCode, 406);
-  
+
   var resp = Meteor.http.get('http://localhost:3000/server/baz-5')
   test.equal(resp.content, 'data');
 });
@@ -70,10 +70,10 @@ Tinytest.add("Router.serve with futures", function(test) {
     setTimeout(function() {
       fut.ret('foo-in-timeout');
     }, 1);
-        
+
     return fut.wait();
   });
-  
+
   var resp = Meteor.http.get('http://localhost:3000/server/delayed')
   test.equal(resp.content, 'foo-in-timeout');
 });


### PR DESCRIPTION
The Meteor Router test suite will now run on ports other than 3000.
To see this in action, invoke `mrt` with a non-standard port:

``` sh
$ mrt --port 3030
```

This work replaces all hand-constructed test paths with [`Meteor.absoluteUrl()`](http://docs.meteor.com/#meteor_absoluteurl).

Also removed trailing spaces and added semicolons per the [Meteor Style Guide](https://github.com/meteor/meteor/wiki/Meteor-Style-Guide).
