### PR TITLE
Add `previousPage` and `back` methods

### DIFF
--- a/lib/router_client.js
+++ b/lib/router_client.js
@@ -114,9 +114,9 @@
     page(path);
   }
   
-  Router.prototype.back = function(default) {
-    if (typeof default === 'undefined') default = null;
-    this.to(this._oldPage || default);
+  Router.prototype.back = function(defaultPath) {
+    if (typeof defaultPath === 'undefined') defaultPath = null;
+    this.to(this._oldPage || defaultPath);
   }
   
   Router.prototype.filters = function(filtersMap) {

--- a/lib/router_client.js
+++ b/lib/router_client.js
@@ -114,8 +114,9 @@
     page(path);
   }
   
-  Router.prototype.back = function() {
-    this.to(this._oldPage);
+  Router.prototype.back = function(default) {
+    if (typeof default === 'undefined') default = null;
+    this.to(this._oldPage || default);
   }
   
   Router.prototype.filters = function(filtersMap) {

--- a/lib/router_client.js
+++ b/lib/router_client.js
@@ -31,10 +31,11 @@
       var oldPage = self._page;
       self._page = self._applyFilters(pageFn.apply(context, args));
       
-      // no need to invalidate if .page() hasn't changed
-      var changed = (oldPage !== self._page) && self._pageDeps.changed();
-      
+      // set the previous page, if changed
       if (oldPage !== self._page) self._oldPage = oldPage;
+      
+      // no need to invalidate if .page() hasn't changed
+      (oldPage !== self._page) && self._pageDeps.changed();
     })
   }
   

--- a/lib/router_client.js
+++ b/lib/router_client.js
@@ -1,6 +1,7 @@
 (function() {
   var Router = function() {
     this._page = null;
+    this._oldPage = null;
     this._autorunHandle = null;
     
     this._filters = {};
@@ -31,7 +32,9 @@
       self._page = self._applyFilters(pageFn.apply(context, args));
       
       // no need to invalidate if .page() hasn't changed
-      (oldPage !== self._page) && self._pageDeps.changed();
+      var changed = (oldPage !== self._page) && self._pageDeps.changed();
+      
+      if (oldPage !== self._page) self._oldPage = oldPage;
     })
   }
   
@@ -91,6 +94,11 @@
     return this._page;
   }
   
+  Router.prototype.previousPage = function() {
+    Deps.depend(this._pageDeps);
+    return this._oldPage;
+  }
+  
   Router.prototype.to = function(path) {
     // named route
     if (path[0] !== '/') {
@@ -103,6 +111,10 @@
     }
     
     page(path);
+  }
+  
+  Router.prototype.back = function() {
+    this.to(this._oldPage);
   }
   
   Router.prototype.filters = function(filtersMap) {


### PR DESCRIPTION
This adds two methods. `Meteor.Router.previousPage()` returns the previous page, and works like `Meteor.Router.page()`. `Meteor.Router.back()` navigates to the previous page, and works like `Meteor.Router.to()` but without an argument.
