### PR TITLE
Add route abort feature when beforeRouting returns false

### DIFF
--- a/lib/router_client.js
+++ b/lib/router_client.js
@@ -12,7 +12,8 @@
   
   // internal, don't use
   Router.prototype._setPageFn = function(pageFn, context) {
-    var self = this;
+    var self = this,
+		interrupt;
     
     // the current function that generates self._page
     // we could just store pageFn and call it everytime someone
@@ -21,7 +22,10 @@
     // unexpected if it has side effects. This is essentially a memoize pattern
     self._autorunHandle && self._autorunHandle.stop();
     self._autorunHandle = Deps.autorun(function() {
-      self.beforeRouting(context);
+      interrupt = self.beforeRouting(context);
+	  if (interrupt != undefined && interrupt === false) {
+		return;
+	  }
       
       var args = [];
       for (key in context.params)

--- a/tests/router_client_tests.js
+++ b/tests/router_client_tests.js
@@ -169,3 +169,25 @@ Tinytest.add("Router before routing", function(test) {
   Meteor.Router.to('/before');
   test.equal(beforeCalled, true);
 });
+
+Tinytest.add("Router before routing interrupt", function(test) {
+  var beforeCalled = false;
+  
+  Meteor.Router.resetFilters();
+  
+  Meteor.Router.beforeRouting = function() {
+	// a method (i.e. returns undefined) should not interrupt routing 
+  }
+
+  Meteor.Router.to('/route1');
+  Meteor.flush();
+  test.equal(Meteor.Router.page(), 'page1');
+  
+  Meteor.Router.beforeRouting = function() {
+	// returning false should interrupt (block) routing
+	return false;
+  }
+
+  Meteor.Router.to('/route2');
+  test.equal(Meteor.Router.page(), 'page1');
+});


### PR DESCRIPTION
This pull request adds the functionality whereby returning false in the beforeRouting callback will prevent the route from occurring.

This is useful, for example, if one wants to detect unsaved changes and present a modal dialog to allow the route to abort if need be.

Test included.
