### PR TITLE
Return undefined in the route method to tell that you ended the response yourself

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ Meteor.Router.add({
 });
 ```
 
+The route function's return value is one of:
+
+  - the template name as shown above: `'showPost`'
+  - a text sent as body in the response
+  - an array `[status, text]`, for example `[404, "Sorry, not found"]`
+  - an array `[status, header, text]`
+  - `false` to indicate that the router should not end the response
+  - `undefined` to indicate that you ended the response, i. e. you called `this.response.end()` or you piped to the response.
+  
+
 ### Named Routes
 
 If you specify your route with simply a template name, then you'll set up a _named route_. So instead of calling `Meteor.Router.to('/news')`, you can call `Meteor.Router.to('news')` (`news` is the name of the route). Additionally, that named route sets up the following:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Meteor.Router.add({
 
 The route function's return value is one of:
 
-  - the template name as shown above: `'showPost`'
+  - a template name as shown above: `'showPost'`
   - a text sent as body in the response
   - an array `[status, text]`, for example `[404, "Sorry, not found"]`
   - an array `[status, header, text]`

--- a/lib/router_server.js
+++ b/lib/router_server.js
@@ -84,7 +84,8 @@
 
           if (output === false) {
             return next();
-          } else {
+          }
+          else if (typeof(output)!="undefined") {
             // parse out the various type of response we can have
 
             // array can be


### PR DESCRIPTION
See http://stackoverflow.com/q/17073431/220060 for a use case.

We had a similar use case. We need to stream a file with seek to implement pseudostreaming.

I also updated the documentation. Our team got very confused when they discovered that they could return a text instead of a template name. I read the source code and documented what's possible. Of course I added the new possibility to return undefined.
