### PR TITLE
Router failing without explicit dependencies for Meteor 0.6.5

### DIFF
--- a/package.js
+++ b/package.js
@@ -5,6 +5,8 @@ Package.describe({
 Package.on_use(function (api, where) {
   api.use('deps', 'client');
   api.use('startup', 'client');
+  api.use('templating', 'client');
+  api.use('handlebars', 'client');
   api.use('page-js-ie-support', 'client');
   api.use('underscore', ['client', 'server']);
   


### PR DESCRIPTION
I was helping someone with updating their Meteor project to use the `devel` branch and realized that the missing packages were making Router fail silently because you check for `Handlebars !== undefined`.

This may or may not be everything that Router needs to be properly updated, but it worked fine for us after adding these. You should update as necessary.
